### PR TITLE
Added ELSE to POST_FILE_CHANGE check so the postProcessing flag is se…

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -85,7 +85,9 @@ if 'POST_FILE_COMMAND' in globals():
    postProcessing = True
    logging.debug("POST_FILE_COMMAND will be executed after file creation. Command = ")
    logging.debug(POST_FILE_COMMAND)
-   
+else:
+   postProcessing = False
+
 def makePNGTitle(title):
     return ''.join([HTML_DIR,'/',re.sub('[^\w\-_]', '_', title),'.png'])
     


### PR DESCRIPTION
…t. Otherwise, this fails.

Again, sorry about the error. I added this as if the POST_COMMAND is simply commented out (like in the other fork) then the program will try to execute a command after the files are created. This patch makes sure that if the line is commented, nothing will happen.