### PR TITLE
Make headless run

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,10 +35,12 @@ DATA_DWELL_TIME = 60
 LOG_LEVEL = logging.WARN
 #
 """images directory, or None if not writing image files"""
-IMAGE_DIR = '.'
+IMAGE_DIR = '/mnt/ramdisk/n1mm_view/html'
 IMAGE_WIDTH = 1920
 IMAGE_HEIGHT = 1080
 """ set HEADLESS True to not open graphics window. This is for using only the Apache option."""
 HEADLESS = False
-""" If set, this command is run after creating the files (used to rsync PNG files to a remote web server) """
-POST_FILE_COMMAND = None  # 'rsync -avz <HTML_DIR from above/*> <user@server>/<remote dir>'
+
+# This should match the directory above we want to send from the directory to which we write.
+POST_FILE_COMMAND = 'rsync -avz /mnt/ramdisk/n1mm_view/html/* sparc:www/n1mm_view/html'
+

--- a/dataaccess.py
+++ b/dataaccess.py
@@ -111,9 +111,9 @@ def get_last_qso(cursor) :
     message = ''
     for row in cursor:
         last_qso_time = row[0]
-    message = 'Last QSO: %s %s %s on %s by %s at %s' % (
-        row[1], row[2], row[3], constants.Bands.BANDS_TITLE[row[5]], row[4],
-        datetime.utcfromtimestamp(row[0]).strftime('%H:%M:%S'))
+        message = 'Last QSO: %s %s %s on %s by %s at %s' % (
+            row[1], row[2], row[3], constants.Bands.BANDS_TITLE[row[5]], row[4],
+            datetime.utcfromtimestamp(row[0]).strftime('%H:%M:%S'))
     logging.debug(message)
     return last_qso_time, message
 
@@ -202,4 +202,5 @@ def get_qsos_by_section(cursor):
     cursor.execute('SELECT section, COUNT(section) AS qsos FROM qso_log GROUP BY section;')
     for row in cursor:
         qsos_by_section[row[0]] = row[1]
+        logging.debug('Section %s',row[0])
     return qsos_by_section

--- a/graphics.py
+++ b/graphics.py
@@ -100,6 +100,7 @@ def show_graph(screen, size, surf):
 
 def save_image(image_data, image_size, filename):
     surface = pygame.image.frombuffer(image_data, image_size, 'RGB')
+    logging.info('Saving file to %s', filename)       
     pygame.image.save(surface, filename)
     pass
 
@@ -490,8 +491,12 @@ def draw_map(size, qsos_by_section):
     ax.add_feature(cfeature.LAND, color='#113311')
 
     ax.coastlines('50m')
-
-    ranges = [0, 1, 10, 20, 50, 100, 200]  # , 500]  # , 1000]
+    ax.annotate('Sections Worked', xy=(0.5, 1), xycoords='axes fraction', ha='center', va='top',
+                color='white', size=48, weight='bold')
+    
+    ax.text(0.83, 0,datetime.datetime.utcnow().strftime("%d %b %Y %H:%M %Zz"),
+               transform = ax.transAxes,style='italic', size=14,color='white')
+    ranges = [0, 1, 2, 10, 20, 50, 100]  # , 500]  # , 1000]
     num_colors = len(ranges)
     color_palette = matplotlib.cm.viridis(np.linspace(0.33, 1, num_colors + 1))
 


### PR DESCRIPTION
This change fixes a few issues with headless operation. It handles creating the directory in the RAM drive if not there as well as adds a timestamp to the sections chart. This closes #27 and closed #28.