### PR TITLE
Change Golden Horseshoe to GH

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -87,7 +87,7 @@ CONTEST_SECTIONS = {
     'EPA': 'Eastern Pennsylvania',
     'EWA': 'Eastern Washington',
     'GA': 'Georgia',
-    'GS': 'Golden Horseshoe',
+    'GH': 'Golden Horseshoe',
     # 'GTA': 'Greater Toronto Area',  # renamed GS 2023-03-15
     'IA': 'Iowa',
     'ID': 'Idaho',


### PR DESCRIPTION
The correct abbreviation according to the published list from the ARRL is GH for Golden Horseshoe, not GS